### PR TITLE
improved error handling & response flow

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,7 +24,7 @@ pub fn env_default<K: AsRef<OsStr>, D: FromStr>(key: K, default: D) -> D {
     if let Ok(v) = std::env::var(key) {
         match v.parse::<D>() {
             Ok(parsed) => parsed,
-            Err(e) => default,
+            Err(_e) => default,
         }
     } else {
         default


### PR DESCRIPTION
i have finally learned enough to know what error handling should look like, i think.

in particular, we need a way to specify "send normal interaction response to user", "send error response to user", and "send one error to user and another to admins"

this additionally simplifies the process of responding to interactions greatly; i understand enough about the discord API (& my own use case here) to wrap things up at reasonable levels of abstraction, now.

...well, maybe I'm still wrong and I'll rewrite this again, but it feels a lot better now.